### PR TITLE
Do not send query params when requesting a login link for a construction dossier

### DIFF
--- a/src/app/pages/ConstructionDossierPage/components/LoginLinkRequestModal/LoginLinkRequestFlow.test.tsx
+++ b/src/app/pages/ConstructionDossierPage/components/LoginLinkRequestModal/LoginLinkRequestFlow.test.tsx
@@ -15,6 +15,15 @@ describe('LoginLinkRequestFlow', () => {
   })
 
   it('requests a login link', () => {
+    const origin = 'http://localhost:3000'
+    const pathname = '/data/bouwdossiers/bouwdossier/ID123456'
+    const locationSpy = jest.spyOn(window, 'location', 'get').mockReturnValue({
+      origin,
+      pathname,
+      // Add the search to ensure it does not accidentally end up in the request.
+      search: '?foo=bar',
+    } as Location)
+
     requestLoginLinkMock.mockReturnValue(new Promise(() => {}))
 
     render(
@@ -25,8 +34,10 @@ describe('LoginLinkRequestFlow', () => {
 
     expect(requestLoginLinkMock).toHaveBeenCalledWith({
       email: MOCK_EMAIL,
-      originUrl: 'http://localhost:3000/',
+      originUrl: origin + pathname,
     })
+
+    locationSpy.mockRestore()
   })
 
   it('shows the loading message', () => {

--- a/src/app/pages/ConstructionDossierPage/components/LoginLinkRequestModal/LoginLinkRequestFlow.tsx
+++ b/src/app/pages/ConstructionDossierPage/components/LoginLinkRequestModal/LoginLinkRequestFlow.tsx
@@ -21,10 +21,8 @@ const LoginLinkRequestFlow: FunctionComponent<LoginLinkRequestFlowProps> = ({
   onRetry,
   onClose,
 }) => {
-  const result = usePromise(
-    () => requestLoginLink({ email, originUrl: window.location.href }),
-    [email],
-  )
+  const originUrl = window.location.origin + window.location.pathname
+  const result = usePromise(() => requestLoginLink({ email, originUrl }), [email])
 
   if (isPending(result)) {
     return (


### PR DESCRIPTION
The API cannot handle query params, which creates invalid links with a double querystring. Removing the query params before requesting a login link fixes this issue.