### PR TITLE
Convert MapLegend to typescript

### DIFF
--- a/src/app/pages/MapPage/legacy/services/index.ts
+++ b/src/app/pages/MapPage/legacy/services/index.ts
@@ -33,6 +33,7 @@ export interface MapLayer {
 
 export interface LegendItem {
   __typename: 'LegendItem'
+  id: string
   title: string
   iconUrl?: string
   imageRule?: string


### PR DESCRIPTION
Here's the initial commit with a working version of the MapLegend in Typescript. I've had to add a few `// @ts-ignore` comments in the MapLegend and also make one change to the LegendItem type, which I will run through in comments.

Primary issue is that there seems to be some conflicts between the mapLayer and legendItem vars/types - hopefully I've just used the wrong type.

Also still need to write a test for this