### PR TITLE
Dossiers fix for conditionals inadvertently outputting numbers

### DIFF
--- a/src/app/pages/ConstructionDossierPage/components/DocumentDetails/DocumentDetails.tsx
+++ b/src/app/pages/ConstructionDossierPage/components/DocumentDetails/DocumentDetails.tsx
@@ -113,7 +113,7 @@ const DocumentDetails: FunctionComponent<DocumentDetailsProps> = ({
           </>
         )}
       </DocumentHeaderBlock>
-      {dossier.olo_liaan_nummer && (
+      {dossier.olo_liaan_nummer ? (
         <DefinitionList data-testid="oloLiaanNumberDescription">
           {document.document_omschrijving && (
             <DefinitionListItem term="Beschrijving">
@@ -127,7 +127,7 @@ const DocumentDetails: FunctionComponent<DocumentDetailsProps> = ({
           )}
           <DefinitionListItem term="Openbaarheid">{document.access}</DefinitionListItem>
         </DefinitionList>
-      )}
+      ) : null}
       <GalleryContainer data-testid="filesGalleryContainer">
         {document.bestanden.length > 0 ? (
           <>

--- a/src/app/pages/ConstructionDossierPage/components/DossierDetails/DossierDetails.tsx
+++ b/src/app/pages/ConstructionDossierPage/components/DossierDetails/DossierDetails.tsx
@@ -131,11 +131,11 @@ const DossierDetails: FunctionComponent<DossierDetailsProps> = ({
           <DefinitionListItem term="Type">{dossier.dossier_type}</DefinitionListItem>
           <DefinitionListItem term="Dossiernummer">{dossier.dossiernr}</DefinitionListItem>
           <DefinitionListItem term="Openbaarheid">{dossier.access}</DefinitionListItem>
-          {dossier.olo_liaan_nummer && (
+          {dossier.olo_liaan_nummer ? (
             <DefinitionListItem term="OLO of liaan nummer" data-testid="oloLiaanNumber">
               {dossier.olo_liaan_nummer}
             </DefinitionListItem>
-          )}
+          ) : null}
         </DefinitionList>
 
         {hasRights && !disableDownload && (


### PR DESCRIPTION
DocumentDetails and DossierDetails have conditionals for the olo_liaan_nummer that are sometimes outputting the value as well as the expected JSX.

You can see this with the dossier: data/bouwdossiers/bouwdossier/SDCP103742/