### PR TITLE
Dossier image viewer and alert positioning conflict fix

### DIFF
--- a/src/app/AppBody.tsx
+++ b/src/app/AppBody.tsx
@@ -51,6 +51,16 @@ const StyledLoadingSpinner = styled(LoadingSpinner)`
   top: 200px;
 `
 
+const FullHeightContainer = styled.div`
+  height: 100%;
+  overflow-y: auto;
+`
+
+const FullHeightBlock = styled.div`
+  position: relative;
+  height: 100%;
+`
+
 export interface AppBodyProps {
   hasGrid: boolean
 }
@@ -110,8 +120,8 @@ const AppBody: FunctionComponent<AppBodyProps> = ({ hasGrid }) => {
                   <div className="c-dashboard__body">
                     <NotificationAlert />
 
-                    <div className="u-full-height u-overflow--y-auto">
-                      <div className="u-full-height">
+                    <FullHeightContainer>
+                      <FullHeightBlock>
                         <Switch>
                           <Route
                             path={routing.constructionDossier.path}
@@ -124,8 +134,8 @@ const AppBody: FunctionComponent<AppBodyProps> = ({ hasGrid }) => {
                             component={DatasetDetailPage}
                           />
                         </Switch>
-                      </div>
-                    </div>
+                      </FullHeightBlock>
+                    </FullHeightContainer>
                   </div>
                 </Route>
                 <Route path={[routing.data.path]}>

--- a/src/shared/legacy-styles/_legacy-utils.scss
+++ b/src/shared/legacy-styles/_legacy-utils.scss
@@ -16,9 +16,6 @@
 .u-margin__left--1 {
   margin-left: 1 * $base-whitespace !important;
 }
-.u-overflow--y-auto {
-  overflow-y: auto;
-}
 .u-padding__bottom--1 {
   padding-bottom: 1 * $base-whitespace !important;
 }

--- a/src/shared/legacy-styles/_shared.scss
+++ b/src/shared/legacy-styles/_shared.scss
@@ -9,7 +9,6 @@
 @import 'components/paragraph';
 @import 'components/table';
 @import 'components/tag';
-@import 'components/utilities/full-height';
 @import 'components/dashboard';
 @import 'components/dcatd/datasets';
 @import 'components/data-selection/data-selection';

--- a/src/shared/legacy-styles/components/utilities/_full-height.scss
+++ b/src/shared/legacy-styles/components/utilities/_full-height.scss
@@ -1,3 +1,0 @@
-.u-full-height {
-  height: 100%;
-}


### PR DESCRIPTION
Fix for the dossier close button sitting on top of an alert