### PR TITLE
Enable Silent SSO for Keycloak

### DIFF
--- a/public/static/silent-check-sso.html
+++ b/public/static/silent-check-sso.html
@@ -1,0 +1,7 @@
+<html>
+  <body>
+    <script>
+      parent.postMessage(location.href, location.origin);
+    </script>
+  </body>
+</html>

--- a/src/shared/services/auth/auth-keycloak.ts
+++ b/src/shared/services/auth/auth-keycloak.ts
@@ -38,6 +38,7 @@ export async function initKeycloak() {
     checkLoginIframe: false,
     pkceMethod: 'S256',
     onLoad: 'check-sso',
+    silentCheckSsoRedirectUri: `${window.location.origin}/silent-check-sso.html`,
   })
 
   if (authenticated) {


### PR DESCRIPTION
Allows the client to check the Keycloak session without redirecting to Keycloak on page load.