### PR TITLE
Fix for unclickable dossier imageviewer close button

### DIFF
--- a/src/app/pages/ConstructionDossierPage/components/ImageViewer/ImageViewer.tsx
+++ b/src/app/pages/ConstructionDossierPage/components/ImageViewer/ImageViewer.tsx
@@ -42,6 +42,10 @@ const NavigationButtons = styled.div`
   pointer-events: all;
 `
 
+const CloseButton = styled(Button)`
+  pointer-events: all;
+`
+
 const ZoomControls = styled.div`
   pointer-events: all;
 `
@@ -260,7 +264,7 @@ const ImageViewer: FunctionComponent<ImageViewerProps> = ({
             ) : null
           }
           topRightComponent={
-            <Button
+            <CloseButton
               type="button"
               variant="blank"
               title="Bestand sluiten"


### PR DESCRIPTION
Small fix to resolve the ImageViewer close button being unclickable due to ImageViewer OSD CSS click-through changes